### PR TITLE
Add configurable compiler to global section

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ _[n.global]_
 
 ```filter``` = string to identify and recurse into library .h files in #include statements and exclude standard headers
 
+```cpp_compiler``` = string to specify a CPP compiler executable. [default: g++]
+
+```c_compiler``` = string to specify a C compiler executable. [default: gcc]
+
 _[n.include]_
 
 List of all directories, one per line, to include in the search path. This is used by:-

--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ __Capabilities & Limitations__
 
 Nimgen supports compiling in C/C++ sources and static libraries as well as loading in dynamic libraries.
 
-Environment variables are supported via Nim's string interpolation `%` symbol imported from the `strutils` module. Simply use double quotes to enclose any value and put `${}` around the environment variable name. In addition, the `output` var from the n.global section is available as ${output}. For example:
+Environment variables are supported via Nim's string interpolation `%` symbol imported from the `strutils` module. Simply use double quotes to enclose any value and put `$` or `${}` around the environment variable name. In addition, the `output` var from the n.global section is available as ${output}. For example:
 
     [n.global]
+    c_compiler="$CC"
+    cpp_compiler="${CPP}-arm"
     output="src/path"
 
     [n.include]
     "${output}/library/include"
+    "${MY_INCLUDE_PATH}/include"
 
 To see examples of nimgen in action check out the following wrappers:-
 * Link with a dynamic library

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ __Capabilities & Limitations__
 
 Nimgen supports compiling in C/C++ sources and static libraries as well as loading in dynamic libraries.
 
+Environment variables are supported via Nim's string interpolation `%` symbol imported from the `strutils` module. Simply use double quotes to enclose any value and put `${}` around the environment variable name. In addition, the `output` var from the n.global section is available as ${output}. For example:
+
+    [n.global]
+    output="src/path"
+
+    [n.include]
+    "${output}/library/include"
+
 To see examples of nimgen in action check out the following wrappers:-
 * Link with a dynamic library
     * [nimbass](https://github.com/genotrance/nimbass) - BASS audio wrapper: [docs](http://nimgen.genotrance.com/nimbass)

--- a/README.md
+++ b/README.md
@@ -30,17 +30,6 @@ __Capabilities & Limitations__
 
 Nimgen supports compiling in C/C++ sources and static libraries as well as loading in dynamic libraries.
 
-Environment variables are supported via Nim's string interpolation `%` symbol imported from the `strutils` module. Simply use double quotes to enclose any value and put `$` or `${}` around the environment variable name. In addition, the `output` var from the n.global section is available as ${output}. For example:
-
-    [n.global]
-    c_compiler="$CC"
-    cpp_compiler="${CPP}-arm"
-    output="src/path"
-
-    [n.include]
-    "${output}/library/include"
-    "${MY_INCLUDE_PATH}/include"
-
 To see examples of nimgen in action check out the following wrappers:-
 * Link with a dynamic library
     * [nimbass](https://github.com/genotrance/nimbass) - BASS audio wrapper: [docs](http://nimgen.genotrance.com/nimbass)
@@ -75,6 +64,17 @@ To see examples of nimgen in action check out the following wrappers:-
 Nimgen only supports the ```gcc``` preprocessor at this time. Support for detecting and using other preprocessors will be based on interest.
 
 __Config file__
+
+In all sections below, environment variables are supported via Nim's string interpolation `%` symbol imported from the `strutils` module. Simply use double quotes to enclose any value and put `$` or `${}` around the environment variable name. In addition, the `output` var from the n.global section is available as ${output}. For example:
+
+    [n.global]
+    c_compiler="$CC"
+    cpp_compiler="${CPP}-arm"
+    output="src/path"
+
+    [n.include]
+    "${output}/library/include"
+    "${MY_INCLUDE_PATH}/include"
 
 _[n.global]_
 

--- a/nimgen.nim
+++ b/nimgen.nim
@@ -35,6 +35,33 @@ Options:
 # ###
 # Helpers
 
+proc addEnv(str: string): string =
+  var newStr = str
+  for pair in envPairs():
+    try:
+      newStr = newStr % [pair.key, pair.value.string]
+    except ValueError:
+      # Ignore if there are no values to replace. We
+      # want to continue anyway
+      discard
+
+  try:
+    newStr = newStr % ["output", gOutput]
+  except ValueError:
+    # Ignore if there are no values to replace. We
+    # want to continue anyway
+    discard
+
+  # if there are still format args, print a warning
+  if newStr.contains("${"):
+    echo "WARNING: \"", newStr, "\" still contains an uninterpolated value!"
+
+  return newStr
+
+proc `[]`(table: OrderedTableRef[string, string], key: string): string =
+  ## Gets table values with env vars inserted
+  tables.`[]`(table, key).addEnv
+
 proc execProc(cmd: string): string =
   result = ""
   var
@@ -497,6 +524,7 @@ proc c2nim(fl, outfile: string, c2nimConfig: c2nimConfigObj) =
     outpragma &= "{." & prag & ".}\n"
 
   let fname = file.splitFile().name.replace(re"[\.\-]", "_")
+
   if c2nimConfig.dynlib.len() != 0:
     let
       win = "when defined(Windows):\n"
@@ -599,7 +627,9 @@ proc runFile(file: string, cfgin: OrderedTableRef) =
       if action == "create":
         createDir(file.splitPath().head)
         writeFile(file, cfg[act])
-      elif action in @["prepend", "append", "replace", "comment", "rename", "compile", "dynlib", "pragma", "pipe"] and sfile != "":
+      elif action in @["prepend", "append", "replace", "comment",
+                       "rename", "compile", "dynlib", "pragma",
+                       "pipe"] and sfile != "":
         if action == "prepend":
           if srch != "":
             prepend(sfile, cfg[act], cfg[srch])
@@ -700,30 +730,31 @@ proc runCfg(cfg: string) =
 
   if gConfig.hasKey("n.include"):
     for inc in gConfig["n.include"].keys():
-      gIncludes.add(inc)
+      gIncludes.add(inc.addEnv())
 
   if gConfig.hasKey("n.exclude"):
     for excl in gConfig["n.exclude"].keys():
-      gExcludes.add(excl)
+      gExcludes.add(excl.addEnv())
 
   if gConfig.hasKey("n.prepare"):
     for prep in gConfig["n.prepare"].keys():
       let (key, val) = getKey(prep)
       if val == true:
+        let prepVal = gConfig["n.prepare"][prep]
         if key == "download":
-          downloadUrl(gConfig["n.prepare"][prep])
+          downloadUrl(prepVal)
         elif key == "extract":
-          extractZip(gConfig["n.prepare"][prep])
+          extractZip(prepVal)
         elif key == "git":
-          gitRemotePull(gConfig["n.prepare"][prep])
+          gitRemotePull(prepVal)
         elif key == "gitremote":
-          gitRemotePull(gConfig["n.prepare"][prep], false)
+          gitRemotePull(prepVal, false)
         elif key == "gitsparse":
-          gitSparseCheckout(gConfig["n.prepare"][prep])
+          gitSparseCheckout(prepVal)
         elif key == "execute":
-          discard execProc(gConfig["n.prepare"][prep])
+          discard execProc(prepVal)
         elif key == "copy":
-          doCopy(gConfig["n.prepare"][prep])
+          doCopy(prepVal)
 
   if gConfig.hasKey("n.wildcard"):
     var wildcard = ""
@@ -733,7 +764,8 @@ proc runCfg(cfg: string) =
         if key == "wildcard":
           wildcard = gConfig["n.wildcard"][wild]
         else:
-          gWildcards.setSectionKey(wildcard, wild, gConfig["n.wildcard"][wild])
+          gWildcards.setSectionKey(wildcard, wild,
+                                   gConfig["n.wildcard"][wild])
 
   for file in gConfig.keys():
     if file in @["n.global", "n.include", "n.exclude", "n.prepare", "n.wildcard"]:

--- a/nimgen.nim
+++ b/nimgen.nim
@@ -1,5 +1,11 @@
 import nre, os, ospaths, osproc, parsecfg, pegs, ropes, sequtils, streams, strutils, tables
 
+const
+  C_COMPILER_ENV = "CC"
+  CPP_COMPILER_ENV = "CPP"
+  DEFAULT_C_COMPILER = "gcc"
+  DEFAULT_CPP_COMPILER = "g++"
+
 var
   gDoneRecursive: seq[string] = @[]
   gDoneInline: seq[string] = @[]
@@ -8,8 +14,8 @@ var
   gConfig: Config
   gFilter = ""
   gQuotes = true
-  gCppCompiler = "g++"
-  gCCompiler = "gcc"
+  gCppCompiler = getEnv(CPP_COMPILER_ENV, DEFAULT_C_COMPILER)
+  gCCompiler = getEnv(C_COMPILER_ENV, DEFAULT_CPP_COMPILER)
   gOutput = ""
   gIncludes: seq[string] = @[]
   gExcludes: seq[string] = @[]
@@ -719,8 +725,15 @@ proc runCfg(cfg: string) =
 
     if gConfig["n.global"].hasKey("cpp_compiler"):
       gCppCompiler = gConfig["n.global"]["cpp_compiler"]
+    else:
+      # Reset on a per project basis
+      gCppCompiler = getEnv(CPP_COMPILER_ENV, DEFAULT_CPP_COMPILER)
+
     if gConfig["n.global"].hasKey("c_compiler"):
       gCCompiler = gConfig["n.global"]["c_compiler"]
+    else:
+      # Reset on a per project basis
+      gCCompiler = getEnv(C_COMPILER_ENV, DEFAULT_C_COMPILER)
 
     if gConfig["n.global"].hasKey("filter"):
       gFilter = gConfig["n.global"]["filter"]

--- a/nimgen.nim
+++ b/nimgen.nim
@@ -7,6 +7,8 @@ var
   gConfig: Config
   gFilter = ""
   gQuotes = true
+  gCppCompiler = "g++"
+  gCCompiler = "gcc"
   gOutput = ""
   gIncludes: seq[string] = @[]
   gExcludes: seq[string] = @[]
@@ -369,7 +371,7 @@ proc getDefines(file: string, inline=false): string =
 
 proc runPreprocess(file, ppflags, flags: string, inline: bool): string =
   var
-    pproc = if flags.contains("cpp"): "g++" else: "gcc"
+    pproc = if flags.contains("cpp"): gCppCompiler else: gCCompiler
     cmd = "$# -E $# $#" % [pproc, ppflags, file]
 
   for inc in gIncludes:
@@ -670,6 +672,11 @@ proc runCfg(cfg: string) =
               echo "Unable to delete: " & f
               quit(1)
       createDir(gOutput)
+
+    if gConfig["n.global"].hasKey("cpp_compiler"):
+      gCppCompiler = gConfig["n.global"]["cpp_compiler"]
+    if gConfig["n.global"].hasKey("c_compiler"):
+      gCCompiler = gConfig["n.global"]["c_compiler"]
 
     if gConfig["n.global"].hasKey("filter"):
       gFilter = gConfig["n.global"]["filter"]

--- a/nimgen.nim
+++ b/nimgen.nim
@@ -1,10 +1,10 @@
 import nre, os, ospaths, osproc, parsecfg, pegs, ropes, sequtils, streams, strutils, tables
 
 const
-  C_COMPILER_ENV = "CC"
-  CPP_COMPILER_ENV = "CPP"
-  DEFAULT_C_COMPILER = "gcc"
-  DEFAULT_CPP_COMPILER = "g++"
+  cCompilerEnv = "CC"
+  cppCompilerEnv = "CPP"
+  defaultCCompiler = "gcc"
+  defaultCppCompiler = "g++"
 
 var
   gDoneRecursive: seq[string] = @[]
@@ -14,8 +14,8 @@ var
   gConfig: Config
   gFilter = ""
   gQuotes = true
-  gCppCompiler = getEnv(CPP_COMPILER_ENV, DEFAULT_C_COMPILER)
-  gCCompiler = getEnv(C_COMPILER_ENV, DEFAULT_CPP_COMPILER)
+  gCppCompiler = getEnv(cppCompilerEnv, defaultCCompiler)
+  gCCompiler = getEnv(cCompilerEnv, defaultCppCompiler)
   gOutput = ""
   gIncludes: seq[string] = @[]
   gExcludes: seq[string] = @[]
@@ -727,13 +727,13 @@ proc runCfg(cfg: string) =
       gCppCompiler = gConfig["n.global"]["cpp_compiler"]
     else:
       # Reset on a per project basis
-      gCppCompiler = getEnv(CPP_COMPILER_ENV, DEFAULT_CPP_COMPILER)
+      gCppCompiler = getEnv(cppCompilerEnv, defaultCppCompiler)
 
     if gConfig["n.global"].hasKey("c_compiler"):
       gCCompiler = gConfig["n.global"]["c_compiler"]
     else:
       # Reset on a per project basis
-      gCCompiler = getEnv(C_COMPILER_ENV, DEFAULT_C_COMPILER)
+      gCCompiler = getEnv(cCompilerEnv, defaultCCompiler)
 
     if gConfig["n.global"].hasKey("filter"):
       gFilter = gConfig["n.global"]["filter"]


### PR DESCRIPTION
Add a section in the global config to be able to specify the compiler. This makes it easy to switch to other compilers that still accept gcc's arguments, like aarch64-linux-gcc and others.