### PR TITLE
Allow for deeper than one directory paths for the output directory

### DIFF
--- a/nimgen.nim
+++ b/nimgen.nim
@@ -651,7 +651,7 @@ proc runCfg(cfg: string) =
     echo "Config doesn't exist: " & cfg
     quit(1)
 
-  gProjectDir = parentDir(cfg)
+  gProjectDir = parentDir(cfg.expandFilename())
 
   gConfig = loadConfig(cfg)
 


### PR DESCRIPTION
Allows for paths such as ```src/projectName```, which is the recommended nim directory structure.