### PR TITLE
Add support for executing a command on a file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ The following keys apply to library source code (before processing) and generate
 
 ```search``` = search string providing context for following prepend/append/replace directives
 
+```execute``` = execute a command on a file and store the output of the command as the new file contents. Ex: execute = "cat $file | grep 'static inline'"
+
 ```prepend``` = string value to prepend into file at beginning or before search
 
 ```append``` = string value to append into file at the end or after search

--- a/nimgen.nim
+++ b/nimgen.nim
@@ -228,6 +228,12 @@ proc prepend(file: string, data: string, search="") =
       if idx != -1:
         content = content[0..<idx] & data & content[idx..<content.len()]
 
+proc execute(file: string, command: string) =
+  withFile(file):
+    let cmd = command % ["file", file]
+    let commandResult = execProc(cmd)
+    content = commandResult
+
 proc append(file: string, data: string, search="") =
   withFile(file):
     if search == "":
@@ -587,7 +593,7 @@ proc runFile(file: string, cfgin: OrderedTableRef) =
       if action == "create":
         createDir(file.splitPath().head)
         writeFile(file, cfg[act])
-      elif action in @["prepend", "append", "replace", "comment", "rename", "compile", "dynlib", "pragma"] and sfile != "":
+      elif action in @["prepend", "append", "replace", "comment", "rename", "compile", "dynlib", "pragma", "execute"] and sfile != "":
         if action == "prepend":
           if srch != "":
             prepend(sfile, cfg[act], cfg[srch])
@@ -612,6 +618,8 @@ proc runFile(file: string, cfgin: OrderedTableRef) =
           c2nimConfig.dynlib.add(cfg[act])
         elif action == "pragma":
           c2nimConfig.pragma.add(cfg[act])
+        elif action == "execute":
+          execute(sfile, cfg[act])
         srch = ""
       elif action == "search":
         srch = act


### PR DESCRIPTION
$file in the command string references the file name. The stdout of the
command will become the file's new contents. This is useful for doing
things that nimgen might not support, like using sed or grep or some
other command line tool.