### PR TITLE
Only include necessary file for include libs

### DIFF
--- a/nimgen.nim
+++ b/nimgen.nim
@@ -490,11 +490,18 @@ proc c2nim(fl, outfile: string, c2nimConfig: c2nimConfigObj) =
   passC = "import strutils\n"
   passC &= "import ospaths\n"
 
+  for inc in gIncludes:
+    let relativeInc = inc.replace(gOutput & $DirSep, "")
+    passC &= (
+      """{.passC: "-I\"" & currentSourcePath().splitPath().head & "/$#\"".}""" %
+      [relativeInc]
+    ) & "\n"
+
   for prag in c2nimConfig.pragma:
     outpragma &= "{." & prag & ".}\n"
 
   let fname = file.splitFile().name.replace(re"[\.\-]", "_")
-  let fincl = file.replace(gOutput, "")
+  let fincl = file.replace(gOutput & $DirSep, "")
 
   if c2nimConfig.dynlib.len() != 0:
     let

--- a/nimgen.nim
+++ b/nimgen.nim
@@ -491,11 +491,14 @@ proc c2nim(fl, outfile: string, c2nimConfig: c2nimConfigObj) =
   passC &= "import ospaths\n"
 
   for inc in gIncludes:
-    let relativeInc = inc.replace(gOutput, "")
-    passC &= (
-      """{.passC: "-I\"" & currentSourcePath().splitPath().head & "/$#\"".}""" %
-      [relativeInc]
-    ) & "\n"
+    if inc.isAbsolute:
+      passC &= ("""{.passC: "-I\"$#\"".}""" % [inc]) & "\n"
+    else:
+      let relativeInc = inc.replace(gOutput, "")
+      passC &= (
+        """{.passC: "-I\"" & currentSourcePath().splitPath().head & "/$#\"".}""" %
+        [relativeInc]
+      ) & "\n"
 
   for prag in c2nimConfig.pragma:
     outpragma &= "{." & prag & ".}\n"

--- a/nimgen.nim
+++ b/nimgen.nim
@@ -488,13 +488,14 @@ proc c2nim(fl, outfile: string, c2nimConfig: c2nimConfigObj) =
     outpragma = ""
 
   passC = "import strutils\n"
-  for inc in gIncludes:
-    passC &= ("""{.passC: "-I\"" & gorge("nimble path $#").strip() & "/$#\"".}""" % [gOutput, inc]) & "\n"
+  passC &= "import ospaths\n"
 
   for prag in c2nimConfig.pragma:
     outpragma &= "{." & prag & ".}\n"
 
   let fname = file.splitFile().name.replace(re"[\.\-]", "_")
+  let fincl = file.replace(gOutput, "")
+
   if c2nimConfig.dynlib.len() != 0:
     let
       win = "when defined(Windows):\n"
@@ -524,7 +525,12 @@ proc c2nim(fl, outfile: string, c2nimConfig: c2nimConfigObj) =
     if outlib != "":
       extflags &= " --dynlib:dynlib$#" % fname
   else:
-    passC &= "const header$# = \"$#\"\n" % [fname, fl]
+    if file.isAbsolute():
+      passC &= "const header$# = \"$#\"\n" % [fname, fincl]
+    else:
+      # based on the current source directory, get the include path
+      # works for nimble installations and local repo clones
+      passC &= "const header$# = currentSourcePath().splitPath().head & \"/$#\"\n" % [fname, fincl]
     extflags = "--header:header$#" % fname
 
   # Run c2nim on generated file

--- a/nimgen.nim
+++ b/nimgen.nim
@@ -491,7 +491,7 @@ proc c2nim(fl, outfile: string, c2nimConfig: c2nimConfigObj) =
   passC &= "import ospaths\n"
 
   for inc in gIncludes:
-    let relativeInc = inc.replace(gOutput & $DirSep, "")
+    let relativeInc = inc.replace(gOutput, "")
     passC &= (
       """{.passC: "-I\"" & currentSourcePath().splitPath().head & "/$#\"".}""" %
       [relativeInc]
@@ -501,7 +501,7 @@ proc c2nim(fl, outfile: string, c2nimConfig: c2nimConfigObj) =
     outpragma &= "{." & prag & ".}\n"
 
   let fname = file.splitFile().name.replace(re"[\.\-]", "_")
-  let fincl = file.replace(gOutput & $DirSep, "")
+  let fincl = file.replace(gOutput, "")
 
   if c2nimConfig.dynlib.len() != 0:
     let


### PR DESCRIPTION
The previous behavior caused a "Too many files open" error when
referrencing lots of libs because of the call to "gorge". This
modification retains the old behavior and also works if the library is
compiled locally.

Fixes #12