### PR TITLE
Add section for resetting files

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ The following keys can be used to prepare dependencies such as downloading ZIP f
 
 ```copy``` = copy a file to another location. Preferred over moving to preserve original. Comma separate for multiple entries. E.g. copy = "output/config.h.in=output/config.h"
 
+_[n.post]_
+
+This section is the same as the prepare section, but for performing actions after the project has been processed.
+
+```reset``` = whether or not to perform a git reset on all files after processing [default: false]
+
+```execute``` = command to run after processing
+
 _[n.wildcard]_
 
 File wildcards such as *.nim, ssl*.h, etc. can be used to perform tasks across a group of files. This is useful to define common operations such as global text replacements without having to specify an explicit section for every single file. These operations will be performed on every matching file that is defined as a _sourcefile_ or recursed files. Only applies on source files following the wildcard declarations.

--- a/nimgen.nim
+++ b/nimgen.nim
@@ -797,10 +797,21 @@ proc runCfg(cfg: string) =
                                    gConfig["n.wildcard"][wild])
 
   for file in gConfig.keys():
-    if file in @["n.global", "n.include", "n.exclude", "n.prepare", "n.wildcard"]:
+    if file in @["n.global", "n.include", "n.exclude",
+                 "n.prepare", "n.wildcard", "n.post"]:
       continue
 
     runFile(file, gConfig[file])
+
+  if gConfig.hasKey("n.post"):
+    for post in gConfig["n.post"].keys():
+      let (key, val) = getKey(post)
+      if val == true:
+        let postVal = gConfig["n.post"][post]
+        if key == "reset":
+          gitReset()
+        elif key == "execute":
+          discard execProc(postVal)
 
 # ###
 # Main loop


### PR DESCRIPTION
This is useful in nim-libnx because removing the bodies of inline static functions causes the library imports to cause compiler errors when the files are still modified. Somewhat related to #10, but this is a global reset. Local resets per file are still useful.

Fixes #9