### PR TITLE
Add `postwildcard` section that operates on files after nimgen has run

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ File wildcards such as *.nim, ssl*.h, etc. can be used to perform tasks across a
 
 ```wildcard``` = pattern to match against. All keys following the wildcard declaration will apply to matched files
 
+_[n.postwildcard]_
+The same as n.wildcard, but instead of operating on the files before nimgen is done generating, it operates after, so you can modify Nim files or other files that result from nimgen or c2nim.
+
+```wildcard``` = pattern to match against. All keys following the wildcard declaration will apply to matched files
+
 _[sourcefile]_
 
 The following keys apply to library source code and help with generating the .nim files. -win, -lin and -osx can be used for OS specific tasks. E.g. dynlib-win, pragma-win


### PR DESCRIPTION
This is useful to me because the resulting nim files in nim-libnx have some issues that are present in every single nim file that need to be replaced, and it's not feasible for me to write a section for each file to search/replace. This makes it easy to modify the resulting nim files in the same way it's easy to modify the source files with `wildcard`.