### PR TITLE
Fix issue with sourcepath building switch on Windows

### DIFF
--- a/src/nimgen/c2nim.nim
+++ b/src/nimgen/c2nim.nim
@@ -36,12 +36,14 @@ proc c2nim*(fl, outfile: string, c2nimConfig: c2nimConfigObj) =
 
   passC = "import ospaths, strutils\n"
 
+  passC &= """const sourcePath = currentSourcePath().split({'\\', '/'})[0..^2].join("/")""" & "\n"
+
   for inc in gIncludes:
     if inc.isAbsolute():
       passC &= ("""{.passC: "-I\"$#\"".}""" % [inc.sanitizePath()]) & "\n"
     else:
       passC &= (
-        """{.passC: "-I\"" & currentSourcePath().splitPath().head & "$#\"".}""" %
+        """{.passC: "-I\"" & sourcePath & "$#\"".}""" %
           inc.relativePath()
       ) & "\n"
 
@@ -82,7 +84,7 @@ proc c2nim*(fl, outfile: string, c2nimConfig: c2nimConfigObj) =
     if file.isAbsolute():
       passC &= "const header$# = \"$#\"\n" % [fname, file]
     else:
-      passC &= "const header$# = currentSourcePath().splitPath().head & \"$#\"\n" %
+      passC &= "const header$# = sourcePath & \"$#\"\n" %
         [fname, file.relativePath()]
     extflags = "--header:header$#" % fname
   # Run c2nim on generated file


### PR DESCRIPTION
The issue is that currentSourcePath() returns a windows path, with backslashes, and splitPath() uses the compilation target's slashes (forward slash for nintendo switch). This patch fixes the computation so it works across any compilation target.

See: https://github.com/nim-lang/Nim/blob/master/lib/pure/ospaths.nim#L225