### PR TITLE
Fix unit test for Windows and quit with failure code

### DIFF
--- a/tests/rununittests.nim
+++ b/tests/rununittests.nim
@@ -1,8 +1,10 @@
 import os, osproc, strutils
 
 proc main() =
+  var failures = 0
   for file in walkFiles(currentSourcePath().splitPath().head / "unittests/*.nim"):
     let (path, fname, ext) = file.splitFile()
     if fname.startswith("test"):
-      discard execCmd "nim c -r " & file
+      failures += execCmd "nim c -r " & file
+  quit(failures)
 main()

--- a/tests/unittests/testfileops.nim
+++ b/tests/unittests/testfileops.nim
@@ -120,7 +120,7 @@ suite "test file ops":
 
   test "pipe command into file":
     when defined(windows):
-      pipe(testfilename, "ECHO foo > $file")
+      pipe(testfilename, "ECHO foo")
       testfilename.checkFile("foo")
     else:
       pipe(testfilename, "cat $file | grep 'this is text'")

--- a/tests/unittests/testfileops.nim
+++ b/tests/unittests/testfileops.nim
@@ -120,7 +120,7 @@ suite "test file ops":
 
   test "pipe command into file":
     when defined(windows):
-      pipe(testfilename, "(ECHO foo)>>$file")
+      pipe(testfilename, "ECHO foo > $file")
       testfilename.checkFile("foo")
     else:
       pipe(testfilename, "cat $file | grep 'this is text'")


### PR DESCRIPTION
This should fix the issues with the tests. `exec` will throw OSError if a non zero status code is received by any of the tests.