### PR TITLE
correct index out of bounds error for execAction

### DIFF
--- a/src/nimgen/external.nim
+++ b/src/nimgen/external.nim
@@ -1,4 +1,4 @@
-import os, osproc, regex, streams, strutils
+import os, osproc, regex, strutils
 
 import globals
 
@@ -22,7 +22,7 @@ proc execAction*(cmd: string): string =
   when defined(Linux) or defined(MacOSX):
     ccmd = "bash -c '" & cmd & "'"
 
-  echo "Running '" & ccmd[0..min(64, len(ccmd))] & "'"
+  echo "Running '" & ccmd[0..<min(64, len(ccmd))] & "'"
   return execProc(ccmd)
 
 proc extractZip*(zipfile: string) =

--- a/tests/unittests/testexternal.nim
+++ b/tests/unittests/testexternal.nim
@@ -1,0 +1,10 @@
+import nimgen/external
+
+import unittest
+
+
+suite "test external":
+  ################## execAction ####################
+
+  test "run a simple command":
+    discard execAction("echo")


### PR DESCRIPTION
I was trying to use the https://github.com/deem0n/nim-nats library and found that I could not successfully invoke nimgen.

```
$ nimgen nats.cfg
Resetting nats
Processing nats/src/version.h
Generating nats/version.nim
Processing nats/src/status.h
Generating nats/status.nim
Processing nats/src/nats.h
Generating nats/nats.nim
Processing nats/nats.nim
fatal.nim(39)            sysFatal
Error: unhandled exception: index 31 not in 0 .. 30 [IndexError]
```

Digging into it, there was an index out of bounds error for the invoked post command.

```
bash -c 'cp nats/nats.nim src/'
31
```

This commit corrects `execAction` and allows for successful processing of the library.