### PR TITLE
Fix off by one error in execAction

### DIFF
--- a/src/nimgen/external.nim
+++ b/src/nimgen/external.nim
@@ -22,7 +22,7 @@ proc execAction*(cmd: string): string =
   when defined(Linux) or defined(MacOSX):
     ccmd = "bash -c '" & cmd & "'"
 
-  echo "Running '" & ccmd[0..min(64, len(ccmd))] & "'"
+  echo "Running '" & ccmd[0..min(64, len(ccmd)-1)] & "'"
   return execProc(ccmd)
 
 proc extractZip*(zipfile: string) =


### PR DESCRIPTION
When the executed command length is less than or equal to 64 characters
in total (including the shell invocation) then echoing the command will
raise an exception. This is because `..` is inclusive. So we were trying
to take one character too big slice from the command string.