### PR TITLE
Support branch names

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ The following keys can be used to prepare dependencies such as downloading ZIP f
 
 ```gitcheckout``` = branch, commit or tag of repository to checkout in following Git command, resets after each use. Use "-b name" for branches
 
+```gitbranch``` = master/main branch of the repository, defaults to `master`
+
 ```gitoutput``` = directory for all following Git commands relative to `n.global:output` [default: `n.global:output` directory]
 
 ```git``` = url of Git repository to clone. Full repo is pulled so gitremote + gitsparse is preferable. Resets if already present

--- a/nimgen.nimble
+++ b/nimgen.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.5.2"
+version       = "0.5.3"
 author        = "genotrance"
 description   = "c2nim helper to simplify and automate the wrapping of C libraries"
 license       = "MIT"

--- a/src/nimgen/external.nim
+++ b/src/nimgen/external.nim
@@ -80,14 +80,15 @@ proc gitCheckout*(file: string) =
     echo "  Retrying ..."
 
 proc gitPull() =
+  let branch = if gGitBranch != "": gGitBranch else: "master"
   if gGitCheckout.len() != 0:
     echo "Checking out " & gGitCheckout
-    discard execProc("git pull --tags origin master")
+    discard execProc("git pull --tags origin " & branch)
     discard execProc("git checkout " & gGitCheckout)
     gGitCheckout = ""
   else:
     echo "Pulling repository"
-    discard execProc("git pull --depth=1 origin master")
+    discard execProc("git pull --depth=1 origin " & branch)
 
 proc gitRemotePull*(url: string, pull=true) =
   if dirExists(gGitOutput/".git"):

--- a/src/nimgen/globals.nim
+++ b/src/nimgen/globals.nim
@@ -23,6 +23,7 @@ var
 
   # State tracking
   gGitCheckout* = ""
+  gGitBranch* = ""
   gGitOutput* = ""
   gProjectDir* = ""
   gCompile*: seq[string] = @[]

--- a/src/nimgen/runcfg.nim
+++ b/src/nimgen/runcfg.nim
@@ -259,6 +259,8 @@ proc runCfg*(cfg: string) =
                 extractZip(prepVal)
               of "gitcheckout":
                 gGitCheckout = prepVal
+              of "gitbranch":
+                gGitBranch = prepVal
               of "gitoutput":
                 gGitOutput = gOutput/prepVal
                 createDir(gGitOutput)


### PR DESCRIPTION
The current version of `nimgen` uses `master` as default branch name when pulling the specified repository. When `nimgen` is used on repositories with a different default branch name, it fails. Furthermore Github has changed the default name of the `master`-branch to `main` for new repositories.

This PR implements a new option to set the master/main branch name. It defaults to `master` for backward compability.

This PR solves https://github.com/genotrance/nimgen/issues/49